### PR TITLE
Addition of function to allow for object params

### DIFF
--- a/lowblocks/variables/LowBlocksVariable.php
+++ b/lowblocks/variables/LowBlocksVariable.php
@@ -3,22 +3,21 @@ namespace Craft;
 
 class LowBlocksVariable
 {
-
 	protected $criteria;
 
 	public function __construct()
 	{
 		$this->criteria = craft()->elements->getCriteria(ElementType::MatrixBlock);
 	}
-	
-    public function id($id)
-    {
-        $this->criteria->id = $id;
-        return $this->criteria->first();
-    }
 
-    public function blocks()
-    {
-        return $this->criteria;
-    }
+	public function id($id)
+	{
+		$this->criteria->id = $id;
+		return $this->criteria->first();
+	}
+
+	public function blocks()
+	{
+		return $this->criteria;
+	}
 }

--- a/lowblocks/variables/LowBlocksVariable.php
+++ b/lowblocks/variables/LowBlocksVariable.php
@@ -20,4 +20,9 @@ class LowBlocksVariable
 	{
 		return $this->criteria;
 	}
+
+	public function blocksParams($params)
+	{
+		return craft()->elements->getCriteria(ElementType::MatrixBlock, $params);
+	}
 }


### PR DESCRIPTION
Hi there,

I've found this function useful on a site we've built - it essentially lets you build up a params object and use it as an object instead of chaining methods into blocks(). Example template use below:

```
{% set blocksParams = {
	fieldId: showings.id,
	type: 'time',
	limit: 1000
} %}

{% if accessibilityFilter and accessibilityFilter != 'audio-described' %}
	{% set blocksParams = blocksParams|merge({
		relatedTo: accessibilityFilter
	}) %}
{% endif %}

{% set showingsBlocks = craft.lowblocks.blocksParams(blocksParams) %}
```

Seems to work well enough for us - although I'm not sure what the `id` method is for and whether or not bypassing `$this->criteria` for the new method will cause a problem. Either way, feel free to either pull or implement in your own way - would appreciate you letting us know if you manage to do this without the extra method or you change its name!